### PR TITLE
Fix duplicate gems in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,9 @@ gem 'rails', '4.1.8'
 
 gem 'coffee-rails', '~> 4.0.0'
 gem 'sass-rails', '~> 4.0.3'
-gem 'compass-rails'
 gem 'jquery-rails'
 gem 'jbuilder', '~> 2.0'
 gem 'uglifier', '>= 1.3.0'
-gem 'autoprefixer-rails'
 
 gem 'devise'
 gem 'devise_invitable'


### PR DESCRIPTION
Duplicate gems in the Gemfile could pose an issue later on if you add a version number to one of them.  But mostly, this removes two annoy notifications while running bundle.
