### PR TITLE
Add staging environmet for deploy

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,16 @@ test:
  <<: *default
  database: db/test.sqlite3
 
+staging:
+ adapter: postgresql
+ encoding: utf8
+ username: <%= ENV["DB_USER"] %>
+ password: <%= ENV["DB_PASSWORD"] %>
+ host: <%= ENV["DB_HOST"] %>
+ port: 5432
+ pool: 10
+ database: <%= ENV["STAGING_DB"] %>
+
 production:
  adapter: postgresql
  encoding: utf8

--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -1,0 +1,11 @@
+server '192.168.111.10', user: 'app', roles: %w{app web}
+
+role :app, %w{app@192.168.111.10}
+role :web, %w{app@192.168.111.10}
+role :db,  %w{app@192.168.111.10}
+
+set :ssh_options, {
+  keys: %w(~/.ssh/id_rsa),
+  forward_agent: false,
+  auth_methods: %w(publickey)
+}

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,6 +3,9 @@
 # Defines a single server with a list of roles and multiple properties.
 # You can define all roles on a single server, or split them:
 
+server 'rails-qa-1.mythicapps.io', user: 'app', roles: %w{app web}
+#server 'db-prd-1.mythicapps.io', user: 'app', roles: %w{app web}
+
 # server 'example.com', user: 'deploy', roles: %w{app db web}, my_property: :my_value
 # server 'example.com', user: 'deploy', roles: %w{app web}, other_property: :other_value
 # server 'db.example.com', user: 'deploy', roles: %w{db}
@@ -17,9 +20,9 @@
 # property set. Specify the username and a domain or IP for the server.
 # Don't use `:all`, it's a meta role.
 
-# role :app, %w{deploy@example.com}, my_property: :my_value
-# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
-# role :db,  %w{deploy@example.com}
+role :app, %w{app@rails-qa-1.mythicapps.io}
+role :web, %w{app@rails-qa-1.mythicapps.io}
+role :db,  %w{app@rails-qa-1.mythicapps.io}
 
 
 
@@ -41,11 +44,11 @@
 #
 # Global options
 # --------------
-#  set :ssh_options, {
-#    keys: %w(/home/rlisowski/.ssh/id_rsa),
-#    forward_agent: false,
-#    auth_methods: %w(password)
-#  }
+set :ssh_options, {
+  keys: %w(~/.ssh/id_rsa),
+  forward_agent: false,
+  auth_methods: %w(publickey)
+}
 #
 # The server-based syntax can be used to override options:
 # ------------------------------------

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,94 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Enable Rack::Cache to put a simple HTTP cache in front of your application
+  # Add `rack-cache` to your Gemfile before enabling this.
+  # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
+  # config.action_dispatch.rack_cache = true
+
+  # Disable Rails's static asset server (Apache or nginx will already do this).
+  config.serve_static_assets = true
+
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = :uglifier
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = true
+
+  # Generate digests for assets URLs.
+  config.assets.digest = true
+
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Set to :debug to see everything in the log.
+  config.log_level = :info
+
+  # Prepend all log lines with the following tags.
+  # config.log_tags = [ :subdomain, :uuid ]
+
+  # Use a different logger for distributed setups.
+  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = "http://assets.example.com"
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: Rails.application.secrets.domain_name,
+    authentication: "plain",
+    enable_starttls_auto: true,
+    user_name: Rails.application.secrets.email_provider_username,
+    password: Rails.application.secrets.email_provider_password
+  }
+  # ActionMailer Config
+  config.action_mailer.default_url_options = { :host => Rails.application.secrets.domain_name }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = false
+
+
+  # Disable automatic flushing of the log to improve performance.
+  # config.autoflush_log = false
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -24,6 +24,15 @@ test:
   secret_key_base: b3eb7d44f511f186797d9c5e842fc186fb9d8fb9ea96b58b4194b6c39ceac12b784e6dbea51718b72914e79986888f31564cf208a4572cba2970664bf99008a1
 
 # Do not keep production secrets in the repository,
+staging:
+  admin_name: <%= ENV["ADMIN_NAME"] %>
+  admin_email: <%= ENV["ADMIN_EMAIL"] %>
+  admin_password: <%= ENV["ADMIN_PASSWORD"] %>
+  email_provider_username: <%= ENV["MANDRILL_USERNAME"] %>
+  email_provider_apikey: <%= ENV["MANDRILL_APIKEY"] %>
+  domain_name: <%= ENV["DOMAIN_NAME"] %>
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
 # instead read values from the environment.
 production:
   admin_name: <%= ENV["ADMIN_NAME"] %>


### PR DESCRIPTION
This sets up the staging environment for capistrano deploys.

To use staging:

```
bundle exec cap staging deploy
```

and production:

```
bundle exec cap production deploy
```

This requires the addition of a new environmental variable, `STAGING_DB`.  Both `rails-prd-1` and `rails-qa-1` have been updated to have this variable.
